### PR TITLE
Add link to issues page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-You're probably after the [rails oceania wiki](https://github.com/rails-oceania/roro/wiki) or maybe [Ruby Australia](http://ruby.org.au).
+You're probably after the [rails oceania wiki](https://github.com/rails-oceania/roro/wiki) or maybe [Ruby Australia](http://ruby.org.au). If you're wanting to request or submit a presentation, head for the [Issues page](https://github.com/rails-oceania/roro/issues)


### PR DESCRIPTION
I'm not sure if this is the best way to publicise the link to presentations, but I found it a little hard to find.

Alternatively, maybe it should be mentioned in the wiki.